### PR TITLE
Team Clarifications

### DIFF
--- a/assets/bundles/bundle.properties
+++ b/assets/bundles/bundle.properties
@@ -70,7 +70,7 @@ setting.cui-alertStyle.name =Alert's style:
 setting.cui-alertStyle.description =Default: Circle
 setting.cui-AlertsUseBottom.name =Bottom Toasts alerts
 setting.cui-AlertsHideWithUi.name =Custom Toasts
-setting.cui-AlertsHideWithUi.description =Whether to use custom toast or built in ones
+setting.cui-AlertsHideWithUi.description =Whether to use custom toast or built in ones \nreduces conflict with world logic toasts
 setting.cui-SendChatCoreLost.name =Send a CHAT message on a Core's Death
 setting.cui-ShowAlertsCircles.name =Draw a Circle on a Core's Death
 setting.cui-alertCircleSpeed.name =Alert Grow speed:
@@ -79,6 +79,8 @@ setting.cui-alertCircleAlpha.name =Alert Circle Transparency:
 setting.cui-playerHoldTrackMouse.name =Hold spectate mouse
 setting.cui-alertReverseGrow.name =Reverse Alert growth
 setting.cui-alertReverseGrow.description =Depending on the map size, the alert might take longer\nHover on Alert Circle Speed for more info 
+setting.cui-alertsOtherPlayers.name =Send TOAST to other players (host only)
+setting.cui-alertsOtherPlayers.description =May conflict with world logic based toasts
 
 setting.cui-hotkeys-category.name =HotKey options
 
@@ -103,13 +105,17 @@ setting.cui-ShowResourceRate.name =Show Resource rate ([scarlet]not working[])
 setting.cui-ShowBlockInfo.name =[accent]Show Block info
 setting.cui-showFactoryProgressStyle.name =[accent]Factory progress:
 setting.cui-showFactoryProgressStyle.description =Default: % + Bottom Bar
-setting.cui-logicLineAlpha.name =[accent]Logic Transparency:
-setting.cui-logicLineAlpha.description =Default: 40%
 setting.cui-rallyPointAlpha.name =Hovered Rally point Transparency:
 setting.cui-rallyPointAlpha.description =Default: 30%
 setting.cui-ShowBlockHealth.name =Show Block Health
 setting.cui-BlockInfoShortenItems.name =Shorten Block info Item Numbers
 setting.cui-BlockInfoShortenItems.description =Item numbers are shown full/raw numbers or shorten to 1k, 2b etc
+setting.cui-BlockInfoLastPlayer.name =Display last Interactor
+setting.cui-logicLineAlpha.name =[accent]Logic Transparency:
+setting.cui-logicLineAlpha.description =Default: 40%
+setting.cui-logicLineLimit.name =Logic Line Limit:
+setting.cui-logicLineRange.name =Logic Line Range:
+
 setting.cui-blockinfostyle.name =Block info Table Style
 setting.cui-blockinfostyle.description =Default: Black3\nApplies next map change / Ui rebuilt
 setting.cui-blockinfoSide.name =Block Info Side:
@@ -118,6 +124,8 @@ setting.cui-blockinfo-x.name =Block Info X Offset:
 setting.cui-blockinfo-y.name =Block Info Y Offset:
 setting.cui-domination-toggle.name =[accent]Show Block Counter
 setting.cui-domination-vertical.name =Vertical Block Counter
+setting.cui-domination-TeamIcons.name =Show Team Icons
+setting.cui-domination-TeamIcons.description =Applies next map change / Ui rebuilt
 setting.cui-domination-side.name =Domination Side
 setting.cui-domination-x.name =Block Count X offset
 setting.cui-domination-y.name =Block Count Y offset
@@ -146,6 +154,7 @@ setting.cui-unitsPlayerTableUpdateRate.description =Default: 10
 setting.cui-animateSettings.name =Animate settings category
 setting.cui-TeamItemsUpdateRate.name =Team Items Update rate
 setting.cui-TeamItemsUpdateRate.description =Default: Normal, \nFast to use every tick, \nNormal to update every (update speed * 2)~\nSlow to update every (update speed * 5)~
+setting.cui-updateAvailable = Cui {0} is out! kindly update the mod thx 
 
 setting.cui-teams-category.name =Team options
 setting.cui-ShowTeamItems.name =[accent]Display Team items
@@ -165,15 +174,11 @@ cui-hiddenInfo =Units to show/hide in Unit table
 cui-hiddenCoreUnits =Hidden Core units
 cui-hiddenCoreInfo =Units to ignore for `Hide Core units`
 cui-unbind =Unbind
+cui-filterTeams =Filter Teams
 
 settings.cui-preset =Presets
 settings.cui-preset.disclaimer =This will [scarlet]override all settings[]
 settings.cui-reset =Reset [scarlet]ALL[] to Defaults
-
-keybind.toggle_table_core_units.name =Counter Toggle Core units
-keybind.toggle_units_player_table_controls.name =Counter Toggle Controls
-keybind.toggle_table_summarize_players.name =Counter Summarize player list
-keybind.toggle_cui_kill_switch.description =THIS IS ONE WAY, YOU'LL NEED TO MENU TO TURN THE MOD ON!
 
 
 cui-blockinfostyle-s0 =ButtonTrans
@@ -234,6 +239,14 @@ cui-block-info.stored =Stored
 cui-block-info.health =Heath
 cui-block-info.rally =Rally
 
+cui-domination.tip=Changes are only saved if you leave this dialog!
+
+cui-teams-sort.base =Sort:\n
+cui-teams-sort.0 =Id
+cui-teams-sort.1 =Hue
+cui-teams-sort.2 =Saturation
+cui-teams-sort.3 =Sum
+
 units-table.button.hide.tooltip =Show / Hide everything
 units-table.button.hide-units.tooltip =Show / Hide Units table
 units-table.button.core-units.tooltip =Show / Hide Core Units
@@ -242,10 +255,16 @@ units-table.button.compact-player-list.tooltip =Summarize Player list
 units-info-workaround =Pan to spectate player
 
 keybind.track_cursor.name =Track mouse instead
-keybind.toggle_cui_menu.name =Hide CUI hud/menu
 keybind.last_destroyed_core.name =Pan to last destroyed Core
 keybind.spectate_previous_player.name =Spectate next player
 keybind.spectate_next_player.name =Spectate previous player
+keybind.toggle_table_core_units.name =Counter Toggle Core units
+keybind.toggle_units_player_table_controls.name =Counter Toggle Controls
+keybind.toggle_table_summarize_players.name =Counter Summarize player list
+keybind.toggle_cui_kill_switch.description =THIS IS ONE WAY, YOU'LL NEED TO MENU TO TURN THE MOD ON!
+keybind.cui-camera-mapping.name =Cui Camera Mappings [scarlet](WIP)[]
+keybind.toggle_cui_menu.name =Hide CUI hud/menu
+keybind.toggle_cui_menu.description =This is ignored if Cui is set to visble with the game's hud!
 
 alerts.basic =Core Destroyed!
 alerts.destroy =Destroyed!

--- a/mod.hjson
+++ b/mod.hjson
@@ -2,8 +2,8 @@ name: "caster-ui-java"
 displayName: "Caster User interface"
 description: "Aming to make the client a bit better for casting! with ease of use, simplicity and elegance in mind \n \n Java rewrite of 'JiroCab/Caster-Ui' which was based off 'Ferlern/extended-UI' \nconflicts with 'Ferlern/extended-UI'  \n\nPLEASE DON'T THIS FOR AN ADVANTAGE IN PVP THANKS"
 author: "RushieWashie, WMF Industries"
-subtitle: "v4.4 Helping you cast games~"
-version: 4.5
+subtitle: "v4.6 Helping you cast games~"
+version: 4.6
 
 minGameVersion: 140.4
 hidden: true

--- a/src/casterui/CuiVars.java
+++ b/src/casterui/CuiVars.java
@@ -10,7 +10,9 @@ import casterui.io.CuiInputs;
 import casterui.io.ui.CuiFragment;
 import casterui.io.ui.CuiWorldRenderer;
 import casterui.io.ui.dialog.*;
+import casterui.util.*;
 import mindustry.Vars;
+import mindustry.game.*;
 import mindustry.gen.Player;
 import mindustry.gen.Unit;
 import mindustry.mod.Mods;
@@ -30,12 +32,14 @@ public class CuiVars {
     public static CuiInputs inputs = new CuiInputs();
     public static CuiTeamMangerDialog teamManger = new CuiTeamMangerDialog();
     public static CuiRebindDialog rebindDialog = new CuiRebindDialog();
+    public static TeamBlackListerDialog teamBlackListerDialog = new TeamBlackListerDialog();
+    public static CuiUpdateChecker updateChecker = new CuiUpdateChecker();
 
     public static boolean initialized = false, globalHidden = true, fastUpdate = false, drawRally = false, globalShow = true, animateCats = Core.settings.getBool("cui-animateSettings"), killswitch = false;
     public static Player clickedPlayer;
     public static CoreBlock.CoreBuild clickedCore;
     public static Unit heldUnit, hoveredEntity;
-    public static float  timer = 0, nextUpdate = 100, nextUpdateFast = 50;
+    public static float  timer = 0, nextUpdate = 100, nextUpdateFast = 50, nextVersion = 0.0f;
     public static Tile lastCoreDestroyEvent;
     public static Map<Integer, Player> mappedPlayers = new HashMap<>();
     public static Vec2[] savedCameras = new Vec2[11];
@@ -45,19 +49,20 @@ public class CuiVars {
     public static boolean
             showBlockInfo = false, showCountersUnits = false, showCountersPlayers = false, showCountersButton = false,
             countersSeparateTeams = false, countersCoreUnits = false, countersCoreFlagged = false, countersTotals = false,
-            dominationVertical = false, dominationColoured = false,
+            dominationVertical = false, dominationColoured = false, dominationIcons = false,
             showTeamItems = false, showDomination = false;
-
+    public static boolean[] hiddenTeams = new boolean[Team.all.length];
 
     public static void init(){
+        updateChecker.run();
         CuiSettingsDialog.buildCategory();
         renderer.worldRenderer();
         rebindDialog.load();
         if(Core.settings.getBool("cui-minimalCursor")) overrideCursors();
         animateCats = Core.settings.getBool("cui-animateSettings");
-        Log.info("Caster user interface loaded! happy casting!! owo");
-        //Vars.ui.join.connect("localhost", 6567);  stream lining testing
+        updateHiddenTeams();
 
+        Log.info("Caster user interface loaded! happy casting!! owo");
     }
 
     public static void postInt(){
@@ -142,14 +147,27 @@ public class CuiVars {
 
         if(!full) return;
 
+        updateHiddenTeams();
+
         showTeamItems = settings.getBool("cui-ShowTeamItems");
         showBlockInfo = settings.getBool("cui-ShowBlockInfo");
         showCountersUnits = settings.getBool("cui-ShowUnitTable");
         showCountersPlayers = settings.getBool("cui-ShowPlayerList");
         showDomination = settings.getBool("cui-domination-toggle");
+        dominationIcons = settings.getBool("cui-domination-TeamIcons");
         showCountersButton = settings.getBool("cui-playerunitstablecontols");
         countersSeparateTeams = settings.getBool("cui-separateTeamsUnit");
         countersCoreUnits = settings.getBool("cui-unitsTableCoreUnits");
         countersTotals = settings.getBool("cui-teamtotalunitcount");
+    }
+
+    public static void updateHiddenTeams(){
+        String in = settings.getString("cui-hiddenTeamsList", "0");
+        if(in == null || in.isEmpty()) return;
+        String[] params = in.split(",");
+        for(String param : params){
+            hiddenTeams[Integer.parseInt(param)] = true;
+        }
+
     }
 }

--- a/src/casterui/io/CuiBinding.java
+++ b/src/casterui/io/CuiBinding.java
@@ -35,6 +35,7 @@ public enum CuiBinding implements KeyBinds.KeyBind {
     toggle_alerts_toast(KeyCode.unknown),
     toggle_alerts_toast_bottom(KeyCode.unknown),
     toggle_factory_style(KeyCode.unknown),
+    toggle_domination(KeyCode.unknown),
 
     toggle_cui_kill_switch(KeyCode.unknown),
 

--- a/src/casterui/io/CuiInputs.java
+++ b/src/casterui/io/CuiInputs.java
@@ -77,6 +77,7 @@ public class CuiInputs {
         if(cuiKeyTap(toggle_alerts_toast_bottom)) settings.put("cui-AlertsUseBottom", !settings.getBool("cui-AlertsUseBottom"));
         if(cuiKeyTap(toggle_cui_kill_switch)) settings.put("cui-killswitch", !settings.getBool("cui-killswitch")); //haha this will be one way but lulz
         if(cuiKeyTap(toggle_unit_Cmd_type)) settings.put("cui-unitCmdNonMv", !settings.getBool("cui-unitCmdNonMv"));
+        if(cuiKeyTap(toggle_domination)) settings.put("cui-domination-toggle", !settings.getBool("cui-domination-toggle"));
 
 
 

--- a/src/casterui/io/ui/CuiFragment.java
+++ b/src/casterui/io/ui/CuiFragment.java
@@ -58,6 +58,7 @@ public class CuiFragment {
     Seq<Integer> alignSides = Seq.with(Align.bottom, Align.bottomLeft, Align.bottomRight, Align.top, Align.topLeft, Align.topRight, Align.center, Align.left, Align.right);
     public int[][] blockCats = new int[Team.all.length][Category.all.length + 4];
     public int worldBlocks;
+    public String[] dominationIconList = {Iconc.host + "", Iconc.turret + "", Iconc.production + "", Iconc.distribution + "", Iconc.liquid + "", Iconc.power + "", Iconc.defense + "", Iconc.crafting + "", Iconc.units + "", Iconc.effect + "", Iconc.logic + "", Iconc.home + "",Iconc.map + "", Iconc.list + ""};
 
 
     public void BuildTables(Group parent){
@@ -243,6 +244,7 @@ public class CuiFragment {
         //endregion
         if(showDomination){
             Vars.state.teams.present.each(data -> {
+                if(hiddenTeams[data.team.id]) return;
                 blockCats[data.team.id][11] = data.cores.size;
                 blockCats[data.team.id][12] = data.buildings.size;
                 worldBlocks += data.buildings.size;
@@ -317,6 +319,9 @@ public class CuiFragment {
                     }
                 }
                 if(mouseBuilding.block instanceof Turret)blockTable.label(() -> "[accent]"+  decFor.format(mouseBuilding.sense(LAccess.ammo)) + "[white]/[orange]"+ ((Turret) mouseBuilding.block).maxAmmo).row();
+                if(settings.getBool("cui-ShowBlockHealth") && mouseBuilding.lastAccessed != null){
+                    blockTable.table(a-> a.label(() -> mouseBuilding.lastAccessed).pad(1f));
+                }
                 //TODO: heat, block constructors, Payload
 
             }
@@ -366,21 +371,19 @@ public class CuiFragment {
 
         int trans = settings.getInt("cui-domination-trans");
 
-        String[] icons = {Iconc.host + "", Iconc.turret + "", Iconc.production + "", Iconc.distribution + "", Iconc.liquid + "", Iconc.power + "", Iconc.defense + "", Iconc.crafting + "", Iconc.units + "", Iconc.effect + "", Iconc.logic + "", Iconc.home + "",Iconc.map + "", Iconc.list + ""};
-
         float[] size ={35, 20};
 
         Seq<Label> equlize = new Seq<>(), teamsizes = new Seq<>();
 
         Table iconTab = new Table();
         iconTab.defaults().pad(5f).grow().minWidth(size[0]).minHeight(size[1]).align(Align.center).scaling(Scaling.fill);
-        iconTab.label(() -> " ");
+        if(dominationIcons)iconTab.label(() -> " ");
 
-        for(int i = 0; i < icons.length; i++) {
+        for(int i = 0; i < dominationIconList.length; i++) {
             if (!dominationSettings[i]) continue;
             if(!dominationVertical) iconTab.row();
 
-            Label rawTxt = new Label(icons[i]);
+            Label rawTxt = new Label(dominationIconList[i]);
             rawTxt.setAlignment(Align.center);
 
             if(rawTxt.getMinHeight() > size[1]) size[1] = rawTxt.getMinHeight();
@@ -398,18 +401,20 @@ public class CuiFragment {
             tab.defaults().pad(5f).grow().minWidth(size[0]).minHeight(size[1]).align(Align.center).scaling(Scaling.fill);
 
             float[] tsize ={35, 20};
-            Label team = new Label(Team.get(t).emoji.equals("") ? "[#" + Team.get(t).color + "]#"+ Team.get(t).id + "[]" :  "[white]" +Team.get(t).emoji );
+            if(dominationIcons){
+                Label team = new Label(Team.get(t).emoji.equals("") ? "[#" + Team.get(t).color + "]#"+ Team.get(t).id + "[]" :  "[white]" +Team.get(t).emoji );
+                team.setStyle(Styles.outlineLabel);
+                team.setAlignment(Align.center);
+                tab.add(team);
 
-            team.setStyle(Styles.outlineLabel);
-            team.setAlignment(Align.center);
-            tab.add(team);
+                teamsizes.add(team);
+                if(team.getMinHeight() > tsize[1]) tsize[1] = team.getMinHeight();
+                if(team.getMinWidth() > tsize[0]) tsize[0] = team.getMinWidth();
+            }
 
-            teamsizes.add(team);
-            if(team.getMinHeight() > tsize[1]) tsize[1] = team.getMinHeight();
-            if(team.getMinWidth() > tsize[0]) tsize[0] = team.getMinWidth();
             tab.defaults().minHeight(tsize[1]).minWidth(tsize[0]);
             
-            for(int i = 0; i < icons.length; i++) {
+            for(int i = 0; i < dominationIconList.length; i++) {
                 if (!dominationSettings[i]) continue;
                 //if(!dominationSettings[i]) continue;
                 if(!dominationVertical) tab.row();
@@ -469,9 +474,11 @@ public class CuiFragment {
         if(style == 1){
             //TODO: anything above 1k is hard to see
             Table countTable = new Table(t -> t.center().add(new Label(() -> "[#" + team.color.toString() + "]" + i + "[white]")).style(Styles.outlineLabel).scaling(Scaling.bounded).color(new Color(1, 1, 1, 0.85f)));
+            img.setSize(iconSizes);
             countTable.setColor(new Color(1, 1, 1, 0.85f));
             unitTable.stack(
-                    new Table(t -> t.add(img).scaling(Scaling.bounded).size(iconSizes)),
+                    img.setScaling(Scaling.bounded),
+                    //new Table(t -> t.add(img).scaling(Scaling.bounded).size(iconSizes)),
                     countTable
             ).tooltip(name).size(fsize).scaling(Scaling.bounded).get();
         }else {

--- a/src/casterui/io/ui/dialog/CuiRebindDialog.java
+++ b/src/casterui/io/ui/dialog/CuiRebindDialog.java
@@ -12,7 +12,6 @@ import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
 import arc.struct.*;
 import arc.util.*;
-import casterui.CuiVars;
 import casterui.io.CuiBinding;
 import mindustry.gen.Icon;
 import mindustry.graphics.Pal;
@@ -134,6 +133,7 @@ public class CuiRebindDialog extends KeybindDialog {
                     table.image().color(Color.gray).fillX().height(3).pad(6).colspan(4).padTop(0).padBottom(10).row();
                     lastCategory = keybind.category();
                 }
+                String tip = bundle.getOrNull("keybind." + keybind.name() + ".description");
 
                 if(keybind.defaultValue(section.device.type()) instanceof KeyBinds.Axis){
                     table.add(bundle.get("keybind." + keybind.name() + ".name", Strings.capitalize(keybind.name())), Color.white).left().padRight(40).padLeft(8);
@@ -149,20 +149,28 @@ public class CuiRebindDialog extends KeybindDialog {
                         openDialog(section, keybind);
                     }).width(130f);
                 }else{
-                    table.add(bundle.get("keybind." + keybind.name() + ".name", Strings.capitalize(keybind.name())), Color.white).left().padRight(40).padLeft(8).tooltip(bundle.getOrNull("keybind." + keybind.name() + ".description"));
-                    table.label(() -> cuiKeyBinds.get(section, keybind).key.toString()).color(Pal.accent).left().minWidth(90).padRight(20).tooltip(bundle.getOrNull("keybind." + keybind.name() + ".description"));
+                    Cell<Label> kname = table.add(bundle.get("keybind." + keybind.name() + ".name", Strings.capitalize(keybind.name())), Color.white).left().padRight(40).padLeft(8);
 
-                    table.button("@settings.rebind", tstyle, () -> {
+                    Cell<Label> kbind = table.label(() -> cuiKeyBinds.get(section, keybind).key.toString()).color(Pal.accent).left().minWidth(90).padRight(20);
+
+                    Cell<TextButton> rebBut = table.button("@settings.rebind", tstyle, () -> {
                         rebindAxis = false;
                         rebindMin = false;
                         openDialog(section, keybind);
-                    }).width(130f).tooltip(bundle.getOrNull("keybind." + keybind.name() + ".description"));
+                    }).width(130f);
+
+                    if(tip != null && !tip.isEmpty()){
+                        kname.tooltip(tip);
+                        rebBut.tooltip(tip);
+                        kbind.tooltip(tip);
+                    }
                 }
-                table.button("@settings.resetKey", tstyle, () ->{
+                Cell<TextButton> resKey = table.button("@settings.resetKey", tstyle, () ->{
                     cuiKeyBinds.resetToDefault(section, keybind);
                     settings.remove("cui-keybind-"+keybind.name());
-                }).width(130f).pad(2f).padLeft(4f).tooltip(bundle.getOrNull("keybind." + keybind.name() + ".description"));
+                }).width(130f).pad(2f).padLeft(4f);
                 table.row();
+                if(tip != null && !tip.isEmpty())resKey.tooltip(tip);
             }
 
             table.visible(() -> this.section.equals(section));

--- a/src/casterui/io/ui/dialog/CuiTeamMangerDialog.java
+++ b/src/casterui/io/ui/dialog/CuiTeamMangerDialog.java
@@ -1,30 +1,27 @@
 package casterui.io.ui.dialog;
 
-import arc.Core;
+import arc.*;
 import arc.graphics.g2d.*;
-import arc.input.KeyCode;
-import arc.scene.event.ClickListener;
-import arc.scene.event.Touchable;
+import arc.scene.event.*;
 import arc.scene.ui.*;
 import arc.scene.ui.layout.*;
-import arc.util.Log;
-import arc.util.Scaling;
-import casterui.CuiVars;
-import casterui.io.CuiBinding;
-import mindustry.Vars;
-import mindustry.game.Team;
+import arc.util.*;
+import casterui.*;
+import casterui.io.*;
+import mindustry.*;
+import mindustry.game.*;
 import mindustry.gen.*;
-import mindustry.net.Packets;
-import mindustry.ui.Styles;
-import mindustry.ui.dialogs.BaseDialog;
+import mindustry.net.*;
+import mindustry.ui.*;
+import mindustry.ui.dialogs.*;
 
-import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.*;
 
 /*I'm so sorry */
 public class CuiTeamMangerDialog extends BaseDialog {
     public Player selectedPlayer = Vars.player, lastPlayer = null;
     public Team selectedTeam = Vars.player.team(), lastTeam = null;
-    public int size = 100, teamSize = 40;
+    public int size = 100, teamSize = 50;
     public Cell<ScrollPane> playerPane, teamPane;
     public Table playerTable = new Table(), teamTable = new Table(), header = new Table();
     public boolean clearUnit = true;
@@ -61,9 +58,21 @@ public class CuiTeamMangerDialog extends BaseDialog {
         if (Vars.net.server() || !Vars.net.active() || Vars.player.admin) {
             for (int id = 0 ; id < Team.all.length ; id++){
                 int finalId = id;
-                ImageButton button = teamTable.button(Tex.whiteui, Styles.clearNoneTogglei, 40f, () -> selectedTeam = Team.get(finalId)).tooltip(Team.get(id).emoji.equals("") ? "[#" + Team.get(id).color + "]" + Team.get(id).id + "[]" :  "[white]" +Team.get(id).emoji ).size(teamSize).margin(6f).get();
+
+                ImageButton button = new ImageButton(Tex.whiteui, Styles.clearNoneTogglei);
+                button.clicked(() -> selectedTeam = Team.get(finalId));
+                button.resizeImage(teamSize);
                 button.getImageCell();
                 button.getStyle().imageUpColor = Team.get(id).color;
+
+                Label lab = new Label(Team.get(id).emoji.isEmpty() ? finalId + "":  "[white]" +Team.get(id).emoji);
+
+                lab.touchable(() -> Touchable.disabled);
+                lab.setAlignment(Align.center);
+                teamTable.stack(
+                    button,
+                    lab
+                ).size(teamSize).margin(5f).grow().get();
 
                 if (icons.get() >= 7){
                     teamTable.row();

--- a/src/casterui/io/ui/dialog/TeamBlackListerDialog.java
+++ b/src/casterui/io/ui/dialog/TeamBlackListerDialog.java
@@ -1,0 +1,160 @@
+package casterui.io.ui.dialog;
+
+import arc.*;
+import arc.graphics.*;
+import arc.math.*;
+import arc.scene.actions.*;
+import arc.scene.event.*;
+import arc.scene.ui.*;
+import arc.scene.ui.layout.*;
+import arc.struct.*;
+import arc.util.*;
+import casterui.*;
+import mindustry.game.*;
+import mindustry.gen.*;
+import mindustry.graphics.*;
+import mindustry.ui.*;
+import mindustry.ui.dialogs.*;
+
+public class TeamBlackListerDialog extends BaseDialog{
+    public Cell<ScrollPane> selectedPane, unselectedPane;
+    public int teamSize = 50;
+    public Table selectedTable = new Table(), unselectedTable = new Table(), header = new Table();
+    public int sort = 0;
+    public String sortTxt = "";
+
+
+    public TeamBlackListerDialog(){
+        super("@cui-teamblacklister");
+        rebuildOtherButtons();
+        shown(this::setup);
+        onResize(this::setup);
+        setHideAction(() -> {
+            StringBuilder out = new StringBuilder();
+            boolean first = true;
+            for (int id = 0; id < Team.all.length ; id++){
+                if(CuiVars.hiddenTeams[id] ){
+                    if(first) first = false;
+                    else out.append(",");
+                    out.append(id);
+                }
+            }
+
+            Core.settings.put("cui-hiddenTeamsList", out.toString());
+            CuiVars.updateHiddenTeams();
+            return Actions.fadeOut(0.2F, Interp.fade);
+        });
+    }
+
+
+    void setup() {
+        cont.top();
+        cont.clear();
+        cont.defaults();
+
+        cont.table(a ->{
+            a.label(() -> Core.bundle.get("server.hidden") + " "+ Core.bundle.get("editor.teams")).row();
+            a.image().color(Color.scarlet).height(3f).padTop(5).padBottom(5).growX().row();
+            selectedPane = a.pane(selectedTable).size(a.getWidth(), a.getWidth()).scrollX(false).growX();
+        });
+        cont.table(a ->{
+            a.label(() -> Core.bundle.get("server.shown") + " "+ Core.bundle.get("editor.teams")).row();
+            a.image().color(Pal.accent).height(3f).padTop(5).padBottom(5).growX().row();
+            unselectedPane = a.pane(unselectedTable).size(a.getWidth(), a.getWidth()).scrollX(false).growX();
+        });
+
+        selectedTable.clear();
+        selectedTable.defaults().growX();
+        unselectedTable.clear();
+        unselectedTable.defaults().growX();
+
+        int[] icons = {0, 0, 0, 0};
+
+        Seq<Team> tmSz = new Seq<>();
+        tmSz.addAll(Team.all);
+
+        if(sort == 1) tmSz.sort(t -> t.color.hue());
+        else if(sort == 2)  tmSz.sort(t ->t.color.saturation());
+        else if(sort == 3)  tmSz.sort(t ->t.color.sum());
+        else tmSz.sort(t -> t.id);
+
+
+
+        for (int id = 0; id < tmSz.size ; id++){
+            int finalId = id;
+            boolean selected = CuiVars.hiddenTeams[tmSz.get(finalId).id];
+            Table tab = selected ? selectedTable : unselectedTable;
+
+            ImageButton button = new ImageButton(Tex.whiteui, Styles.clearNoneTogglei);
+            button.clicked(() -> click(selected, tmSz.get(finalId).id));
+            button.resizeImage(teamSize);
+            button.getImageCell();
+            button.getStyle().imageUpColor = tmSz.get(finalId).color;
+
+            Label lab = new Label(tmSz.get(id).emoji.isEmpty() ? tmSz.get(id).id + "":  "[white]" +tmSz.get(id).emoji);
+
+            lab.touchable(() -> Touchable.disabled);
+            lab.setAlignment(Align.center);
+            lab.setStyle(Styles.outlineLabel);
+            tab.stack(
+                button,
+                lab
+            ).size(teamSize).margin(5f).grow().get();
+
+            if(selected){
+                icons[3]++;
+                if (icons[1] >= 7){
+                    tab.row();
+                    icons[1] = 0;
+                } else icons[1]++;
+            } else {
+                icons[2]++;
+                if (icons[0] >= 7){
+                    tab.row();
+                    icons[0] = 0;
+                } else icons[0]++;
+            }
+        }
+        if(icons[2] == 0) unselectedTable.table(t -> t.label(() -> "@empty").growX().center().style(Styles.outlineLabel).pad(20f)).width(selectedPane.maxWidth());
+        if(icons[3] == 0) selectedTable.table(t -> t.label(() -> "@empty").growX().center().style(Styles.outlineLabel).pad(20f)).width(selectedPane.maxWidth());
+    }
+
+    public void click(boolean add, int id){
+        CuiVars.hiddenTeams[id] = !add;
+        setup();
+    }
+
+    void rebuildOtherButtons() {
+        buttons.defaults().size(width, 64f);
+        buttons.button("@back", Icon.left, this::hide).size(210f, 64f).tooltip("@cui-domination.tip");
+
+        addCloseListener();
+
+        buttons.button("@defaults", Icon.exit, () -> {
+            CuiVars.hiddenTeams = new boolean[Team.all.length];
+            CuiVars.hiddenTeams[0] = true;
+            setup();
+
+        }).size(180, 64f);
+        buttons.button("@clear", Icon.trash, () -> {
+            CuiVars.hiddenTeams = new boolean[Team.all.length];
+            setup();
+        }).size(120, 64f);
+        buttons.button("@waves.spawn.all", Icon.move, () -> {
+            CuiVars.hiddenTeams = new boolean[Team.all.length];
+            for(int i = 0; i < Team.all.length; i++) CuiVars.hiddenTeams[i] = true;
+            setup();
+        }).size(120, 64f);
+        sortTxt = Core.bundle.get("cui-teams-sort." + sort);
+        buttons.button(Core.bundle.get("cui-teams-sort.base") + sortTxt, () -> {
+            sort++;
+            if(sort > 3) sort = 0;
+            setup();
+            buttons.clear();
+            rebuildOtherButtons();
+        }).size(150, 64f);
+        titleTable.row();
+        titleTable.add(header);
+
+    }
+}

--- a/src/casterui/util/CuiUpdateChecker.java
+++ b/src/casterui/util/CuiUpdateChecker.java
@@ -1,0 +1,45 @@
+package casterui.util;
+
+import arc.util.*;
+import arc.util.serialization.*;
+import casterui.*;
+import mindustry.mod.Mods.*;
+
+import static arc.Core.bundle;
+import static mindustry.Vars.*;
+
+//Stolen from: https://github.com/ApsZoldat/MindustryMappingUtilities/blob/main/src/java/mu/utils/UpdateChecker.java
+public class CuiUpdateChecker{
+    public boolean out = false;
+
+    public void run(){
+        LoadedMod mod = mods.getMod(CuiMain.class);
+        String repo = mod.getRepo() != null ? mod.getRepo() : "JiroCab/Caster-Ui-Java";
+        out = false;
+
+        Http.get(ghApi + "/repos/" + repo + "/releases", res -> {
+            var json = Jval.read(res.getResultAsString());
+            Jval.JsonArray releases = json.asArray();
+
+            if(releases.size == 0){
+                Log.err("No CUI available for auto-updating 3:");
+                return;
+            }
+
+            Jval release = releases.get(0);
+            String modVersion = mod.meta.version;
+            modVersion = (modVersion.contains(".") ? modVersion : modVersion + ".0");
+            CuiVars.nextVersion = Strings.parseFloat(release.getString("tag_name").replace("v", ""));
+
+            if(Strings.parseFloat(modVersion) >= CuiVars.nextVersion){
+                Log.info("Cui is up to date! ^w^ (c" + modVersion + " r" + Strings.parseFloat(release.getString("tag_name").replace("v", "")) + ")");
+                return;
+            }
+            out = true;
+            Log.info(bundle.format("setting.cui-updateAvailable", CuiVars.nextVersion));
+
+
+        }, thr -> Log.info("Cui failed to fetch updates qmq: @", thr));
+    }
+
+}


### PR DESCRIPTION
- Added a blacklist for block domination
- Added option to display/hide team icons in domination
- Added last interactor in Block info
- Added off to unit HpBar size to allow for text only
- Added option send toast alerts other players (Host w/ cui only)
- Added a indicator when a new cui version is available
- Logic lines can now be limited rendering to mouse, screen or whole map
- Polished Unit filter & PlayerManger Dialogs
- Fixed rebind dialog showing black squares due to tool tip being null